### PR TITLE
테이블 리스트 공통 컴포넌트로 구현

### DIFF
--- a/src/components/About/About.module.css
+++ b/src/components/About/About.module.css
@@ -25,8 +25,8 @@ section {
 p {
   font-size: 1.4rem;
   line-height: 2rem;
-  margin-bottom: 2rem;
 }
+
 p span {
   color: var(--secondary-gray-200);
 }

--- a/src/components/Common/Description/Description.jsx
+++ b/src/components/Common/Description/Description.jsx
@@ -1,0 +1,9 @@
+import styles from "./Description.module.css";
+
+export default function Description({ item }) {
+  return (
+    <>
+      <p className={styles.description}>{item.startup.description}</p>
+    </>
+  );
+}

--- a/src/components/Common/Description/Description.module.css
+++ b/src/components/Common/Description/Description.module.css
@@ -1,0 +1,14 @@
+.description {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+
+    max-width: 30.4rem;
+    max-height: 4.7rem;
+
+    line-height: 1.7rem;
+    text-align: left;
+    text-overflow: ellipsis;
+    line-clamp: 2;
+}

--- a/src/components/Common/Dropdown/Dropdown.module.css
+++ b/src/components/Common/Dropdown/Dropdown.module.css
@@ -6,7 +6,7 @@
 
     max-height: 4.8rem;
 
-    width: 30rem;
+    width: 22rem;
 
     padding: 1.2rem 1.6rem;
 

--- a/src/components/Common/StartupTitle/StartupTitle.jsx
+++ b/src/components/Common/StartupTitle/StartupTitle.jsx
@@ -1,0 +1,11 @@
+import styles from "./StartupTitle.module.css";
+import noImageIcon from "../../../assets/no-image.png";
+
+export default function StartupTitle({ item }) {
+  return (
+    <div className={styles.name}>
+      <img src={item.startup.image || noImageIcon} alt={item.startup.name} />
+      {item.startup.name}
+    </div>
+  );
+}

--- a/src/components/Common/StartupTitle/StartupTitle.module.css
+++ b/src/components/Common/StartupTitle/StartupTitle.module.css
@@ -2,6 +2,8 @@
     display: flex;
     align-items: center;
 
+    padding-left: 3rem;
+
     gap: 1.2rem;
 }
 

--- a/src/components/Common/StartupTitle/StartupTitle.module.css
+++ b/src/components/Common/StartupTitle/StartupTitle.module.css
@@ -1,0 +1,14 @@
+.name {
+    display: flex;
+    align-items: center;
+
+    gap: 1.2rem;
+}
+
+.name img {
+    width: 3.2rem;
+    height: 3.2rem;
+
+    border-radius: 100%;
+    background-color: white;
+}

--- a/src/components/Common/StartupTitle/StartupTitle.module.css
+++ b/src/components/Common/StartupTitle/StartupTitle.module.css
@@ -3,8 +3,9 @@
     align-items: center;
 
     padding-left: 3rem;
-
     gap: 1.2rem;
+
+    text-wrap: nowrap;
 }
 
 .name img {

--- a/src/components/Common/TableList/TableList.jsx
+++ b/src/components/Common/TableList/TableList.jsx
@@ -29,22 +29,6 @@ export default function TableList({ tableHead, list }) {
                     {col.render ? col.render(item) : item[col.key]}
                   </td>
                 ))}
-                {/* <td>{item.rank}위</td>
-                <td>
-                  <div className={styles.name}>
-                    <img
-                      src={item.startup.image || noImageIcon}
-                      alt={item.startup.name}
-                    />
-                    {item.startup.name}
-                  </div>
-                </td>
-                <td className={styles.description}>
-                  {item.startup.description}
-                </td>
-                <td>{item.startup.categoryName}</td>
-                <td>{formatAmount(item.startup.simInvest)} 원</td>
-                <td>{formatAmount(item.startup.actualInvest)} 원</td> */}
               </tr>
             ))}
           </tbody>

--- a/src/components/Common/TableList/TableList.jsx
+++ b/src/components/Common/TableList/TableList.jsx
@@ -3,9 +3,10 @@ import styles from "./TableList.module.css";
 
 export default function TableList({ tableHead, list }) {
   const navigate = useNavigate();
+  const emptyRowCount = Math.max(0, 10 - list.length);
 
   return (
-    <div>
+    <>
       <div className={styles.wrapper}>
         <table className={styles.table}>
           <thead>
@@ -31,9 +32,18 @@ export default function TableList({ tableHead, list }) {
                 ))}
               </tr>
             ))}
+
+            {Array.from({ length: emptyRowCount }).map((_, idx) => (
+              <tr
+                key={`empty-${idx}`}
+                style={{ visibility: "hidden", borderBottom: "none" }}
+              >
+                &nbsp;
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/Common/TableList/TableList.jsx
+++ b/src/components/Common/TableList/TableList.jsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import styles from "./TableList.module.css";
 
-export default function TableList({ tableHead, list }) {
+export default function TableList({ tableData, list }) {
   const navigate = useNavigate();
   const emptyRowCount = Math.max(0, 10 - list.length);
 
@@ -11,7 +11,7 @@ export default function TableList({ tableHead, list }) {
         <table className={styles.table}>
           <thead>
             <tr>
-              {tableHead?.map((head, idx) => (
+              {tableData?.map((head, idx) => (
                 <th key={idx} style={{ width: `${head.width}` }}>
                   {head.title}
                 </th>
@@ -25,7 +25,7 @@ export default function TableList({ tableHead, list }) {
                 onClick={() => navigate(`/startup/${item?.startup.id}`)}
                 style={{ cursor: "pointer" }}
               >
-                {tableHead.map((col, colIndex) => (
+                {tableData.map((col, colIndex) => (
                   <td key={colIndex}>
                     {col.render ? col.render(item) : item[col.key]}
                   </td>

--- a/src/components/Common/TableList/TableList.jsx
+++ b/src/components/Common/TableList/TableList.jsx
@@ -1,0 +1,55 @@
+import { useNavigate } from "react-router-dom";
+import styles from "./TableList.module.css";
+
+export default function TableList({ tableHead, list }) {
+  const navigate = useNavigate();
+
+  return (
+    <div>
+      <div className={styles.wrapper}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              {tableHead?.map((head, idx) => (
+                <th key={idx} style={{ width: `${head.width}` }}>
+                  {head.title}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {list.map((item) => (
+              <tr
+                key={item.id}
+                onClick={() => navigate(`/startup/${item?.startup.id}`)}
+                style={{ cursor: "pointer" }}
+              >
+                {tableHead.map((col, colIndex) => (
+                  <td key={colIndex}>
+                    {col.render ? col.render(item) : item[col.key]}
+                  </td>
+                ))}
+                {/* <td>{item.rank}위</td>
+                <td>
+                  <div className={styles.name}>
+                    <img
+                      src={item.startup.image || noImageIcon}
+                      alt={item.startup.name}
+                    />
+                    {item.startup.name}
+                  </div>
+                </td>
+                <td className={styles.description}>
+                  {item.startup.description}
+                </td>
+                <td>{item.startup.categoryName}</td>
+                <td>{formatAmount(item.startup.simInvest)} 원</td>
+                <td>{formatAmount(item.startup.actualInvest)} 원</td> */}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Common/TableList/TableList.module.css
+++ b/src/components/Common/TableList/TableList.module.css
@@ -60,21 +60,6 @@
     border-bottom: 0.1rem solid var(--secondary-gray-300);
 }
 
-.name {
-    display: flex;
-    align-items: center;
-
-    gap: 1.2rem;
-}
-
-.name img {
-    width: 3.2rem;
-    height: 3.2rem;
-
-    border-radius: 100%;
-    background-color: white;
-}
-
 .table td.description {
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -105,10 +90,6 @@
         padding: 0;
     }
 
-    .br {
-        display: block;
-    }
-
     /* 전체 스크롤바 */
     .wrapper::-webkit-scrollbar {
         width: 100%;
@@ -133,10 +114,6 @@
 @media (max-width: 743px) {
     .table th {
         padding: 0;
-    }
-
-    .br {
-        display: block;
     }
 
     /* 전체 스크롤바 */

--- a/src/components/Common/TableList/TableList.module.css
+++ b/src/components/Common/TableList/TableList.module.css
@@ -48,33 +48,12 @@
     font-weight: 400;
 }
 
-.table tbody td {
+.table tbody tr {
     height: 6.4rem;
-}
-
-.table tbody td:nth-child(2) {
-    font-weight: 500;
 }
 
 .table tbody tr:not(:last-child) {
     border-bottom: 0.1rem solid var(--secondary-gray-300);
-}
-
-.table td.description {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-
-    max-width: 30.4rem;
-    max-height: 4.7rem;
-
-    padding: 1.5rem;
-
-    line-height: 1.7rem;
-    text-align: left;
-    text-overflow: ellipsis;
-    line-clamp: 2;
 }
 
 .null {

--- a/src/components/Common/TableList/TableList.module.css
+++ b/src/components/Common/TableList/TableList.module.css
@@ -1,8 +1,11 @@
 .table {
-    width: 100%;
-
     min-width: 80rem;
+
+    width: 100%;
+    height: 68.5rem;
+
     margin-top: 1.6rem;
+    padding-bottom: auto;
     border-radius: 0.25rem;
 
     overflow: hidden;
@@ -44,11 +47,11 @@
 }
 
 .table tbody {
-    background-color: var(--secondary-black-300);
     font-weight: 400;
 }
 
 .table tbody tr {
+    background-color: var(--secondary-black-300);
     height: 6.4rem;
 }
 

--- a/src/components/Common/TableList/TableList.module.css
+++ b/src/components/Common/TableList/TableList.module.css
@@ -1,0 +1,166 @@
+.table {
+    width: 100%;
+
+    min-width: 80rem;
+    margin-top: 1.6rem;
+    border-radius: 0.25rem;
+
+    overflow: hidden;
+    position: relative;
+}
+
+.wrapper {
+    overflow-x: auto;
+    padding-bottom: 1.2rem;
+}
+
+.table tr:hover {
+    background-color: var(--secondary-black-200);
+    transition: background-color 0.3s ease;
+}
+
+.table th {
+    text-wrap: nowrap;
+}
+
+.table th,
+.table td {
+    padding: 1rem;
+
+    font-size: 1.4rem;
+    line-height: 1.7rem;
+    text-align: center;
+    vertical-align: middle;
+}
+
+.table thead {
+    height: 3.9rem;
+
+    border-bottom: 1.6rem solid var(--secondary-black-400);
+
+    background-color: var(--secondary-black-100);
+    color: white;
+    font-weight: 500;
+}
+
+.table tbody {
+    background-color: var(--secondary-black-300);
+    font-weight: 400;
+}
+
+.table tbody td {
+    height: 6.4rem;
+}
+
+.table tbody td:nth-child(2) {
+    font-weight: 500;
+}
+
+.table tbody tr:not(:last-child) {
+    border-bottom: 0.1rem solid var(--secondary-gray-300);
+}
+
+.name {
+    display: flex;
+    align-items: center;
+
+    gap: 1.2rem;
+}
+
+.name img {
+    width: 3.2rem;
+    height: 3.2rem;
+
+    border-radius: 100%;
+    background-color: white;
+}
+
+.table td.description {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+
+    max-width: 30.4rem;
+    max-height: 4.7rem;
+
+    padding: 1.5rem;
+
+    line-height: 1.7rem;
+    text-align: left;
+    text-overflow: ellipsis;
+    line-clamp: 2;
+}
+
+.null {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+/***** Tablet *****/
+@media (max-width: 1199px) and (min-width: 744px) {
+    .table th {
+        padding: 0;
+    }
+
+    .br {
+        display: block;
+    }
+
+    /* 전체 스크롤바 */
+    .wrapper::-webkit-scrollbar {
+        width: 100%;
+        height: 1.2rem;
+    }
+
+    /* 스크롤바의 트랙 */
+    .wrapper::-webkit-scrollbar-track {
+        background: var(--secondary-black-300);
+        border-radius: 0.8rem;
+    }
+
+    /* 스크롤바 핸들 */
+    .wrapper::-webkit-scrollbar-thumb {
+        background: var(--secondary-black-400);
+        border: 0.3rem solid var(--secondary-black-300);
+        border-radius: 0.8rem;
+    }
+}
+
+/***** Mobile *****/
+@media (max-width: 743px) {
+    .table th {
+        padding: 0;
+    }
+
+    .br {
+        display: block;
+    }
+
+    /* 전체 스크롤바 */
+    .wrapper::-webkit-scrollbar {
+        width: 3.48rem;
+        height: 1.2rem;
+    }
+
+    /* 스크롤바의 트랙 */
+    .wrapper::-webkit-scrollbar-track {
+        background: var(--secondary-black-300);
+        border-radius: 0.8rem;
+    }
+
+    /* 스크롤바 핸들 */
+    .wrapper::-webkit-scrollbar-thumb {
+        background: var(--secondary-black-400);
+        border: 0.3rem solid var(--secondary-black-300);
+        border-radius: 0.8rem;
+    }
+
+    .table td {
+        font-size: 1.2rem;
+        font-weight: 500;
+        line-height: 1.551rem;
+    }
+}

--- a/src/components/PrivacyPolicy/PrivacyPolicy.module.css
+++ b/src/components/PrivacyPolicy/PrivacyPolicy.module.css
@@ -25,7 +25,6 @@ section {
 p {
   font-size: 1.4rem;
   line-height: 2rem;
-  margin-bottom: 2rem;
 }
 
 li {

--- a/src/components/Terms/Terms.module.css
+++ b/src/components/Terms/Terms.module.css
@@ -25,7 +25,6 @@ section {
 p {
   font-size: 1.4rem;
   line-height: 2rem;
-  margin-bottom: 2rem;
 }
 
 li {

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,0 +1,45 @@
+import Description from './components/Common/Description/Description';
+import StartupTitle from './components/Common/StartupTitle/StartupTitle';
+import { formatAmount } from './utils/formatAmount';
+
+export const PAGE_SIZE = 10;
+
+export const INVESTMENT_SORT_OPTIONS = {
+  '모의 누적 투자 금액 높은 순': ['sim_invest', 'desc'],
+  '모의 누적 투자 금액 낮은 순': ['sim_invest', 'asc'],
+  '실제 누적 투자 금액 높은 순': ['actual_invest', 'desc'],
+  '실제 누적 투자 금액 낮은 순': ['actual_invest', 'asc']
+};
+
+export const INVESTMENT_TABLE_DATA = [
+  {
+    title: '순위',
+    width: '6.8rem',
+    render: (item) => item.rank + '위'
+  },
+  {
+    title: '기업 명',
+    width: '21.3rem',
+    render: (item) => <StartupTitle item={item} />
+  },
+  {
+    title: '기업 소개',
+    width: '30.4rem',
+    render: (item) => <Description item={item} />
+  },
+  {
+    title: '카테고리',
+    width: '15.4rem',
+    render: (item) => item.startup.categoryName
+  },
+  {
+    title: '모의 누적 투자 금액',
+    width: '23.1rem',
+    render: (item) => formatAmount(item.startup.simInvest)
+  },
+  {
+    title: '실제 누적 투자 금액',
+    width: '23rem',
+    render: (item) => formatAmount(item.startup.actualInvest)
+  }
+];

--- a/src/pages/InvestmentPage.jsx
+++ b/src/pages/InvestmentPage.jsx
@@ -1,9 +1,11 @@
-import InvestmentList from "../components/Investment/InvestmentList";
 import { useState } from "react";
 import { useGetInvestmentList } from "../api/queries/investmentQuery";
 import Pagination from "../components/Common/Pagination/Pagination";
 import Dropdown from "../components/Common/Dropdown/Dropdown";
 import styles from "../styles/InvestmentPage.module.css";
+import TableList from "../components/Common/TableList/TableList";
+import noImageIcon from "../assets/no-image.png";
+import { formatAmount } from "../utils/formatAmount";
 
 const sortOptions = {
   "View My Startup 누적 투자 금액 높은 순": ["sim_invest", "desc"],
@@ -11,6 +13,53 @@ const sortOptions = {
   "실제 누적 투자 금액 높은 순": ["actual_invest", "desc"],
   "실제 누적 투자 금액 낮은 순": ["actual_invest", "asc"],
 };
+
+const tableHead = [
+  {
+    title: "순위",
+    width: "6.8rem",
+    render: (item) => item.rank,
+  },
+  {
+    title: "기업 명",
+    width: "21.3rem",
+    render: (item) => (
+      <div style={{ display: "flex", alignItems: "center", gap: "1.2rem" }}>
+        <img
+          src={item.startup.image || noImageIcon}
+          alt={item.startup.name}
+          style={{
+            width: "3.2rem",
+            height: "3.2rem",
+            borderRadius: "100%",
+            backgroundColor: "white",
+          }}
+        />
+        {item.startup.name}
+      </div>
+    ),
+  },
+  {
+    title: "기업 소개",
+    width: "30.4rem",
+    render: (item) => item.startup.description,
+  },
+  {
+    title: "카테고리",
+    width: "15.4rem",
+    render: (item) => item.startup.categoryName,
+  },
+  {
+    title: "모의 누적 투자 금액",
+    width: "23.1rem",
+    render: (item) => formatAmount(item.startup.simInvest),
+  },
+  {
+    title: "실제 누적 투자 금액",
+    width: "23rem",
+    render: (item) => formatAmount(item.startup.actualInvest),
+  },
+];
 
 export default function InvestmentPage() {
   const [currentPage, setCurrentPage] = useState(1);
@@ -20,7 +69,7 @@ export default function InvestmentPage() {
     sort: "desc",
   });
 
-  const { data, isLoading, isError, isFetching } = useGetInvestmentList({
+  const { data, isLoading, isError } = useGetInvestmentList({
     currentPage,
     pageSize,
     order: params.order,
@@ -53,7 +102,7 @@ export default function InvestmentPage() {
           sort={params.sort}
         />
       </div>
-      <InvestmentList list={list} />
+      <TableList tableHead={tableHead} list={list} />
       <Pagination
         currentPage={currentPage}
         totalPages={totalPages}

--- a/src/pages/InvestmentPage.jsx
+++ b/src/pages/InvestmentPage.jsx
@@ -4,8 +4,8 @@ import Pagination from "../components/Common/Pagination/Pagination";
 import Dropdown from "../components/Common/Dropdown/Dropdown";
 import styles from "../styles/InvestmentPage.module.css";
 import TableList from "../components/Common/TableList/TableList";
-import noImageIcon from "../assets/no-image.png";
 import { formatAmount } from "../utils/formatAmount";
+import StartupTitle from "../components/Common/StartupTitle/StartupTitle";
 
 const sortOptions = {
   "View My Startup 누적 투자 금액 높은 순": ["sim_invest", "desc"],
@@ -23,21 +23,7 @@ const tableHead = [
   {
     title: "기업 명",
     width: "21.3rem",
-    render: (item) => (
-      <div style={{ display: "flex", alignItems: "center", gap: "1.2rem" }}>
-        <img
-          src={item.startup.image || noImageIcon}
-          alt={item.startup.name}
-          style={{
-            width: "3.2rem",
-            height: "3.2rem",
-            borderRadius: "100%",
-            backgroundColor: "white",
-          }}
-        />
-        {item.startup.name}
-      </div>
-    ),
+    render: (item) => <StartupTitle item={item} />,
   },
   {
     title: "기업 소개",

--- a/src/pages/InvestmentPage.jsx
+++ b/src/pages/InvestmentPage.jsx
@@ -4,53 +4,14 @@ import Pagination from "../components/Common/Pagination/Pagination";
 import Dropdown from "../components/Common/Dropdown/Dropdown";
 import styles from "../styles/InvestmentPage.module.css";
 import TableList from "../components/Common/TableList/TableList";
-import { formatAmount } from "../utils/formatAmount";
-import StartupTitle from "../components/Common/StartupTitle/StartupTitle";
-import Description from "../components/Common/Description/Description";
-
-const sortOptions = {
-  "모의 누적 투자 금액 높은 순": ["sim_invest", "desc"],
-  "모의 누적 투자 금액 낮은 순": ["sim_invest", "asc"],
-  "실제 누적 투자 금액 높은 순": ["actual_invest", "desc"],
-  "실제 누적 투자 금액 낮은 순": ["actual_invest", "asc"],
-};
-
-const tableHead = [
-  {
-    title: "순위",
-    width: "6.8rem",
-    render: (item) => item.rank + "위",
-  },
-  {
-    title: "기업 명",
-    width: "21.3rem",
-    render: (item) => <StartupTitle item={item} />,
-  },
-  {
-    title: "기업 소개",
-    width: "30.4rem",
-    render: (item) => <Description item={item} />,
-  },
-  {
-    title: "카테고리",
-    width: "15.4rem",
-    render: (item) => item.startup.categoryName,
-  },
-  {
-    title: "모의 누적 투자 금액",
-    width: "23.1rem",
-    render: (item) => formatAmount(item.startup.simInvest),
-  },
-  {
-    title: "실제 누적 투자 금액",
-    width: "23rem",
-    render: (item) => formatAmount(item.startup.actualInvest),
-  },
-];
+import {
+  PAGE_SIZE,
+  INVESTMENT_SORT_OPTIONS,
+  INVESTMENT_TABLE_DATA,
+} from "../constant";
 
 export default function InvestmentPage() {
   const [currentPage, setCurrentPage] = useState(1);
-  const pageSize = 10;
   const [params, setParams] = useState({
     order: "sim_invest",
     sort: "desc",
@@ -58,7 +19,7 @@ export default function InvestmentPage() {
 
   const { data, isLoading, isError } = useGetInvestmentList({
     currentPage,
-    pageSize,
+    PAGE_SIZE,
     order: params.order,
     sort: params.sort,
   });
@@ -67,7 +28,7 @@ export default function InvestmentPage() {
   if (isError) return <div>Error..</div>;
 
   const list = data.list;
-  const totalPages = Math.ceil(data.totalCount / pageSize);
+  const totalPages = Math.ceil(data.totalCount / PAGE_SIZE);
 
   // 정렬 처리 함수
   const handleSortChange = (order, sort) => {
@@ -83,13 +44,13 @@ export default function InvestmentPage() {
       <div className={styles.header}>
         <h1 className={styles.title}>투자 현황</h1>
         <Dropdown
-          sortOptions={sortOptions}
+          sortOptions={INVESTMENT_SORT_OPTIONS}
           setSortOrder={handleSortChange}
           order={params.order}
           sort={params.sort}
         />
       </div>
-      <TableList tableHead={tableHead} list={list} />
+      <TableList tableData={INVESTMENT_TABLE_DATA} list={list} />
       <Pagination
         currentPage={currentPage}
         totalPages={totalPages}

--- a/src/pages/InvestmentPage.jsx
+++ b/src/pages/InvestmentPage.jsx
@@ -9,8 +9,8 @@ import StartupTitle from "../components/Common/StartupTitle/StartupTitle";
 import Description from "../components/Common/Description/Description";
 
 const sortOptions = {
-  "View My Startup 누적 투자 금액 높은 순": ["sim_invest", "desc"],
-  "View My Startup 누적 투자 금액 낮은 순": ["sim_invest", "asc"],
+  "모의 누적 투자 금액 높은 순": ["sim_invest", "desc"],
+  "모의 누적 투자 금액 낮은 순": ["sim_invest", "asc"],
   "실제 누적 투자 금액 높은 순": ["actual_invest", "desc"],
   "실제 누적 투자 금액 낮은 순": ["actual_invest", "asc"],
 };

--- a/src/pages/InvestmentPage.jsx
+++ b/src/pages/InvestmentPage.jsx
@@ -19,7 +19,7 @@ const tableHead = [
   {
     title: "순위",
     width: "6.8rem",
-    render: (item) => item.rank,
+    render: (item) => item.rank + "위",
   },
   {
     title: "기업 명",
@@ -79,7 +79,7 @@ export default function InvestmentPage() {
   };
 
   return (
-    <div>
+    <>
       <div className={styles.header}>
         <h1 className={styles.title}>투자 현황</h1>
         <Dropdown
@@ -95,6 +95,6 @@ export default function InvestmentPage() {
         totalPages={totalPages}
         onPageChange={(page) => setCurrentPage(page)}
       />
-    </div>
+    </>
   );
 }

--- a/src/pages/InvestmentPage.jsx
+++ b/src/pages/InvestmentPage.jsx
@@ -6,6 +6,7 @@ import styles from "../styles/InvestmentPage.module.css";
 import TableList from "../components/Common/TableList/TableList";
 import { formatAmount } from "../utils/formatAmount";
 import StartupTitle from "../components/Common/StartupTitle/StartupTitle";
+import Description from "../components/Common/Description/Description";
 
 const sortOptions = {
   "View My Startup 누적 투자 금액 높은 순": ["sim_invest", "desc"],
@@ -28,7 +29,7 @@ const tableHead = [
   {
     title: "기업 소개",
     width: "30.4rem",
-    render: (item) => item.startup.description,
+    render: (item) => <Description item={item} />,
   },
   {
     title: "카테고리",


### PR DESCRIPTION
## 작업 내역
- - [x] 테이블 리스트 공통 컴포넌트 구현
- - [x] 빈공간 넣어서 데이터 부족해도 UI 유지하기
- - [x] 정렬 이름 수정 및 UI 수정
- - [x] 기업 이름 + 이미지 / 기업 설명 공통 컴포넌트로 따로 생성

## 스크린샷
- 임의 공간 넣기 전
![image](https://github.com/user-attachments/assets/26838069-1dca-4c8b-914c-45417bb0023d)

- 임의 공간 넣기 후
![image](https://github.com/user-attachments/assets/111cb62e-3a91-47d9-840c-653fedc32ceb)

## 참고 사항
- 임의 공간을 넣은 이유는 10개 씩 데이터를 표출하는데 다음 페이지에 데이터가 10개가 안되면 UI가 움직여서 좋아보이지 않았음.
